### PR TITLE
refactor: 统一缓存刷新调用并重构调度器与跨服通信

### DIFF
--- a/report.md
+++ b/report.md
@@ -1,0 +1,176 @@
+# 🌸 屎山代码分析报告 🌸
+
+## 📑 目录
+
+- [糟糕指数](#overall-score)
+- [评分指标详情](#metrics-details)
+- [最屎代码排行榜](#problem-files)
+- [诊断结论](#conclusion)
+
+![Score](https://img.shields.io/badge/Score-89%25-brightgreen)
+
+## 糟糕指数 {#overall-score}
+
+| 指标摘要 | 评分 |
+|------|-------|
+| **糟糕指数** | **89.03/100** |
+| 屎山等级 | 🌸 偶有异味 |
+
+> 清新宜人，初闻像早晨的露珠
+
+### 📊 统计信息
+
+| 指标 | 数值 |
+|--------|-------|
+| 总文件数 | 63 |
+| 已跳过 | 16 |
+| 耗时 | 227ms |
+
+## 评分指标详情 {#metrics-details}
+
+| 指标摘要 | 评分 | 状态 |
+|:-----|------:|:------:|
+| 循环复杂度 | 3.95% | ✓✓ |
+| 认知复杂度 | 5.66% | ✓✓ |
+| 嵌套深度 | 7.57% | ✓✓ |
+| 函数长度 | 0.32% | ✓✓ |
+| 文件长度 | 0.03% | ✓✓ |
+| 参数数量 | 1.83% | ✓✓ |
+| 代码重复 | 5.61% | ✓✓ |
+| 结构分析 | 8.94% | ✓✓ |
+| 错误处理 | 25.66% | ✓ |
+| 注释比例 | 98.82% | ✗ |
+| 命名规范 | 6.82% | ✓✓ |
+
+## 最屎代码排行榜 {#problem-files}
+
+### 1. src\main\java\cc\baka9\catseedlogin\bukkit\command\CommandResetPassword.java
+
+**糟糕指数: 52.39**
+
+**问题**: 🔄 复杂度问题: 3, ⚠️ 其他问题: 1, 🏗️ 结构问题: 2, ❌ 错误处理问题: 1, 📝 注释问题: 1
+
+- 🔄 `onCommand()` L20: 复杂度: 20
+- 🔄 `onCommand()` L20: 认知复杂度: 38
+- 🔄 `onCommand()` L20: 嵌套深度: 9
+- 🏗️ `onCommand()` L20: 嵌套过深: 9
+- 🏗️ L1: 循环依赖: 9
+- 🔍 ...还有 1 个问题实在太屎，列不完了
+
+### 2. src\main\java\cc\baka9\catseedlogin\bukkit\command\CommandCatSeedLogin.java
+
+**糟糕指数: 37.22**
+
+**问题**: 🔄 复杂度问题: 4, ⚠️ 其他问题: 2, 📋 重复问题: 1, 🏗️ 结构问题: 3, ❌ 错误处理问题: 1, 📝 注释问题: 1
+
+- 🔄 `delPlayer()` L257: 认知复杂度: 17
+- 🔄 `setPwd()` L292: 认知复杂度: 25
+- 🔄 `delPlayer()` L257: 嵌套深度: 6
+- 🔄 `setPwd()` L292: 嵌套深度: 8
+- 📋 `deathStateQuitRecordLocation()` L48: 重复模式: deathStateQuitRecordLocation, autoKick, canTpSpawnLocation, afterLoginBack, setReenterInterval, beforeLoginNoDamage, limitChineseID, bedrockLoginBypass, LoginwiththesameIP, setIpCountLimit, setIpRegCountLimit
+- 🔍 ...还有 4 个问题实在太屎，列不完了
+
+### 3. src\main\java\cc\baka9\catseedlogin\bukkit\command\CommandChangePassword.java
+
+**糟糕指数: 30.83**
+
+**问题**: 🔄 复杂度问题: 3, ⚠️ 其他问题: 1, 🏗️ 结构问题: 2, 📝 注释问题: 1
+
+- 🔄 `onCommand()` L19: 复杂度: 13
+- 🔄 `onCommand()` L19: 认知复杂度: 25
+- 🔄 `onCommand()` L19: 嵌套深度: 6
+- 🏗️ `onCommand()` L19: 嵌套过深: 6
+- 🏗️ L1: 循环依赖: 8
+
+### 4. src\main\java\cc\baka9\catseedlogin\velocity\Listeners.java
+
+**糟糕指数: 24.71**
+
+**问题**: 🔄 复杂度问题: 3, ⚠️ 其他问题: 1, 📋 重复问题: 1, 🏗️ 结构问题: 3, ❌ 错误处理问题: 1, 📝 注释问题: 1
+
+- 🔄 `onServerPreConnect()` L69: 认知复杂度: 18
+- 🔄 `onServerPreConnect()` L69: 嵌套深度: 6
+- 🔄 `handleLogin()` L141: 嵌套深度: 4
+- 📋 `onChat()` L35: 重复模式: onChat, onServerConnected
+- 🏗️ `onServerPreConnect()` L69: 嵌套过深: 6
+- 🔍 ...还有 3 个问题实在太屎，列不完了
+
+### 5. src\main\java\cc\baka9\catseedlogin\bukkit\command\CommandBindEmail.java
+
+**糟糕指数: 18.64**
+
+**问题**: 🔄 复杂度问题: 4, ⚠️ 其他问题: 1, 🏗️ 结构问题: 4, ❌ 错误处理问题: 1, 📝 注释问题: 1
+
+- 🔄 `onCommand()` L20: 复杂度: 14
+- 🔄 `onCommand()` L20: 认知复杂度: 22
+- 🔄 `onCommand()` L20: 嵌套深度: 4
+- 🔄 `bindEmail()` L107: 嵌套深度: 4
+- 🏗️ `onCommand()` L20: 中等嵌套: 4
+- 🔍 ...还有 4 个问题实在太屎，列不完了
+
+### 6. src\main\java\cc\baka9\catseedlogin\bungee\Listeners.java
+
+**糟糕指数: 18.33**
+
+**问题**: 🔄 复杂度问题: 1, 🏗️ 结构问题: 4, ❌ 错误处理问题: 1, 📝 注释问题: 1, 🏷️ 命名问题: 1
+
+- 🔄 `onServerConnect()` L44: 嵌套深度: 5
+- 🏗️ `onServerConnect()` L44: 嵌套过深: 5
+- 🏗️ `onServerConnected()` L69: 中等嵌套: 3
+- 🏗️ `handleLogin()` L100: 中等嵌套: 3
+- 🏗️ L1: 循环依赖: 1
+- 🔍 ...还有 2 个问题实在太屎，列不完了
+
+### 7. src\main\java\cc\baka9\catseedlogin\bukkit\command\CommandRegister.java
+
+**糟糕指数: 15.62**
+
+**问题**: 🔄 复杂度问题: 2, ⚠️ 其他问题: 1, 🏗️ 结构问题: 2, 📝 注释问题: 1
+
+- 🔄 `onCommand()` L19: 认知复杂度: 18
+- 🔄 `onCommand()` L19: 嵌套深度: 4
+- 🏗️ `onCommand()` L19: 中等嵌套: 4
+- 🏗️ L1: 循环依赖: 8
+
+### 8. src\main\java\cc\baka9\catseedlogin\common\config\ConfigHelper.java
+
+**糟糕指数: 14.92**
+
+**问题**: ⚠️ 其他问题: 1, 📋 重复问题: 1, 📝 注释问题: 1, 🏷️ 命名问题: 1
+
+- 📏 `LocationData()` L49: 6 参数数量
+- 📋 `parseIntOrDefault()` L66: 重复模式: parseIntOrDefault, parseLongOrDefault, parseBooleanOrDefault
+- 🏷️ `LocationData()` L49: "LocationData" - camelCase
+
+### 9. src\main\java\cc\baka9\catseedlogin\bukkit\task\TaskAutoKick.java
+
+**糟糕指数: 13.47**
+
+**问题**: 🔄 复杂度问题: 1, 🏗️ 结构问题: 2, ❌ 错误处理问题: 1, 📝 注释问题: 1
+
+- 🔄 `run()` L14: 嵌套深度: 4
+- 🏗️ `run()` L14: 中等嵌套: 4
+- 🏗️ L1: 循环依赖: 3
+- ❌ L28: 未处理的易出错调用
+
+### 10. src\main\java\cc\baka9\catseedlogin\bukkit\database\SQL.java
+
+**糟糕指数: 12.11**
+
+**问题**: 📋 重复问题: 2, 🏗️ 结构问题: 1, ❌ 错误处理问题: 2, 📝 注释问题: 1
+
+- 📋 `getLocation()` L60: 重复模式: getLocation, get
+- 📋 `getAll()` L86: 重复模式: getAll, getLikeByIp
+- 🏗️ L1: 循环依赖: 1
+- ❌ L71: 未处理的易出错调用
+- ❌ L125: 未处理的易出错调用
+
+## 诊断结论 {#conclusion}
+
+🌸 **偶有异味** - 基本没事，但是有伤风化
+
+👍 继续保持，你是编码界的一股清流，代码洁癖者的骄傲
+
+---
+
+*由 [fuck-u-code](https://github.com/Done-0/fuck-u-code) 生成*

--- a/src/main/java/cc/baka9/catseedlogin/bukkit/CatScheduler.java
+++ b/src/main/java/cc/baka9/catseedlogin/bukkit/CatScheduler.java
@@ -6,11 +6,19 @@ import java.lang.reflect.Method;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
+import space.arim.morepaperlib.MorePaperLib;
 import space.arim.morepaperlib.scheduling.ScheduledTask;
 
 public class CatScheduler {
-    private static final boolean folia = CatSeedLogin.morePaperLib.scheduling().isUsingFolia();
-    private static final Method teleportAsync = initTeleportAsync();
+    private static MorePaperLib morePaperLib;
+    private static boolean folia;
+    private static Method teleportAsync = null;
+
+    public static void init(MorePaperLib mpl) {
+        morePaperLib = mpl;
+        folia = mpl.scheduling().isUsingFolia();
+        teleportAsync = initTeleportAsync();
+    }
 
     private static Method initTeleportAsync() {
         if (folia) {
@@ -29,7 +37,7 @@ public class CatScheduler {
             player.teleport(location);
             return;
         }
-        CatSeedLogin.morePaperLib.scheduling().entitySpecificScheduler(player).run(() -> {
+        morePaperLib.scheduling().entitySpecificScheduler(player).run(() -> {
             try {
                 if (teleportAsync != null) {
                     teleportAsync.invoke(player, location);
@@ -41,30 +49,30 @@ public class CatScheduler {
     }
 
     public static void updateInventory(Player player) {
-        CatSeedLogin.morePaperLib.scheduling().entitySpecificScheduler(player).run(player::updateInventory, null);
+        morePaperLib.scheduling().entitySpecificScheduler(player).run(player::updateInventory, null);
     }
 
     public static ScheduledTask runTaskAsync(Runnable runnable) {
-        return CatSeedLogin.morePaperLib.scheduling().asyncScheduler().run(runnable);
+        return morePaperLib.scheduling().asyncScheduler().run(runnable);
     }
 
     public static ScheduledTask runTaskTimer(Runnable runnable, long delay, long period) {
-        return CatSeedLogin.morePaperLib.scheduling().globalRegionalScheduler().runAtFixedRate(runnable, delay == 0 ? 1 : delay, period);
+        return morePaperLib.scheduling().globalRegionalScheduler().runAtFixedRate(runnable, delay == 0 ? 1 : delay, period);
     }
 
     public static ScheduledTask runTask(Runnable runnable) {
-        return CatSeedLogin.morePaperLib.scheduling().globalRegionalScheduler().run(runnable);
+        return morePaperLib.scheduling().globalRegionalScheduler().run(runnable);
     }
 
     public static ScheduledTask runTaskLater(Runnable runnable, long delay) {
-        return CatSeedLogin.morePaperLib.scheduling().globalRegionalScheduler().runDelayed(runnable, delay);
+        return morePaperLib.scheduling().globalRegionalScheduler().runDelayed(runnable, delay);
     }
 
     public static ScheduledTask runTaskLaterAsync(Runnable runnable, long delay) {
-        return CatSeedLogin.morePaperLib.scheduling().asyncScheduler().runDelayed(runnable, java.time.Duration.ofMillis(delay * 50));
+        return morePaperLib.scheduling().asyncScheduler().runDelayed(runnable, java.time.Duration.ofMillis(delay * 50));
     }
 
     public static ScheduledTask runTaskTimerAsync(Runnable runnable, long delay, long period) {
-        return CatSeedLogin.morePaperLib.scheduling().asyncScheduler().runAtFixedRate(runnable, java.time.Duration.ofMillis(delay * 50), java.time.Duration.ofMillis(period * 50));
+        return morePaperLib.scheduling().asyncScheduler().runAtFixedRate(runnable, java.time.Duration.ofMillis(delay * 50), java.time.Duration.ofMillis(period * 50));
     }
 }

--- a/src/main/java/cc/baka9/catseedlogin/bukkit/CatSeedLogin.java
+++ b/src/main/java/cc/baka9/catseedlogin/bukkit/CatSeedLogin.java
@@ -37,6 +37,7 @@ public class CatSeedLogin extends JavaPlugin implements Listener {
     public void onEnable() {
         instance = this;
         morePaperLib = new MorePaperLib(this);
+        CatScheduler.init(morePaperLib);
         HandySchedulerUtil.init(this);
         getServer().getPluginManager().registerEvents(this, this);
 

--- a/src/main/java/cc/baka9/catseedlogin/bukkit/command/CommandBindEmail.java
+++ b/src/main/java/cc/baka9/catseedlogin/bukkit/command/CommandBindEmail.java
@@ -109,6 +109,7 @@ public class CommandBindEmail implements CommandExecutor {
             try {
                 lp.setEmail(bindEmail.getEmail());
                 CatSeedLogin.sql.edit(lp);
+                Cache.refresh(lp.getName());
                 Bukkit.getScheduler().runTask(CatSeedLogin.instance, () -> {
                     Player syncPlayer = Bukkit.getPlayer(((Player) sender).getUniqueId());
                     if (syncPlayer != null && syncPlayer.isOnline()) {

--- a/src/main/java/cc/baka9/catseedlogin/bukkit/command/CommandCatSeedLogin.java
+++ b/src/main/java/cc/baka9/catseedlogin/bukkit/command/CommandCatSeedLogin.java
@@ -263,6 +263,7 @@ public class CommandCatSeedLogin implements CommandExecutor {
                 CatSeedLogin.instance.runTaskAsync(() -> {
                     try {
                         CatSeedLogin.sql.del(lp.getName());
+                        Cache.refresh(lp.getName());
                         LoginPlayerHelper.remove(lp);
                         sender.sendMessage("§e已删除账户 §a" + lp.getName());
                         CatScheduler.runTask(() -> {
@@ -304,6 +305,7 @@ public class CommandCatSeedLogin implements CommandExecutor {
                     lp.crypt();
                     try {
                         CatSeedLogin.sql.add(lp);
+                        Cache.refresh(lp.getName());
                         sender.sendMessage("§a指定账户不存在,现已注册..");
                     } catch (Exception e) {
                         sender.sendMessage("§c数据库异常!");
@@ -314,6 +316,7 @@ public class CommandCatSeedLogin implements CommandExecutor {
                     lp.crypt();
                     try {
                         CatSeedLogin.sql.edit(lp);
+                        Cache.refresh(lp.getName());
                         LoginPlayerHelper.remove(lp);
                         sender.sendMessage(String.join(" ", "§a玩家", lp.getName(), "密码已设置"));
                         LoginPlayer finalLp = lp;

--- a/src/main/java/cc/baka9/catseedlogin/bukkit/command/CommandChangePassword.java
+++ b/src/main/java/cc/baka9/catseedlogin/bukkit/command/CommandChangePassword.java
@@ -49,6 +49,7 @@ public class CommandChangePassword implements CommandExecutor {
                 lp.setPassword(args[1]);
                 lp.crypt();
                 CatSeedLogin.sql.edit(lp);
+                Cache.refresh(lp.getName());
                 LoginPlayerHelper.remove(lp);
                 CatScheduler.runTask(() -> {
                     Player player = Bukkit.getPlayer(((Player) sender).getUniqueId());

--- a/src/main/java/cc/baka9/catseedlogin/bukkit/command/CommandRegister.java
+++ b/src/main/java/cc/baka9/catseedlogin/bukkit/command/CommandRegister.java
@@ -52,6 +52,7 @@ public class CommandRegister implements CommandExecutor {
                     LoginPlayer lp = new LoginPlayer(name, args[0]);
                     lp.crypt();
                     CatSeedLogin.sql.add(lp);
+                    Cache.refresh(lp.getName());
                     LoginPlayerHelper.add(lp);
                     CatScheduler.runTask(() -> {
                         CatSeedPlayerRegisterEvent event = new CatSeedPlayerRegisterEvent(Bukkit.getPlayer(sender.getName()));

--- a/src/main/java/cc/baka9/catseedlogin/bukkit/command/CommandResetPassword.java
+++ b/src/main/java/cc/baka9/catseedlogin/bukkit/command/CommandResetPassword.java
@@ -82,6 +82,7 @@ public class CommandResetPassword implements CommandExecutor {
                             lp.crypt();
                             try {
                                 CatSeedLogin.sql.edit(lp);
+                                Cache.refresh(lp.getName());
                                 LoginPlayerHelper.remove(lp);
                                 EmailCode.removeByName(name, EmailCode.Type.ResetPassword);
                                 CatScheduler.runTask(() -> {

--- a/src/main/java/cc/baka9/catseedlogin/bukkit/database/SQL.java
+++ b/src/main/java/cc/baka9/catseedlogin/bukkit/database/SQL.java
@@ -42,18 +42,15 @@ public abstract class SQL {
     public void add(LoginPlayer lp) throws Exception {
         flush(new BufferStatement("INSERT INTO accounts (name, password, lastAction, email, ips, location) VALUES (?, ?, ?, ?, ?, ?)",
             lp.getName(), lp.getPassword(), new Date(), lp.getEmail(), lp.getIps(), lp.getLocation()));
-        Cache.refresh(lp.getName());
     }
 
     public void del(String name) throws Exception {
         flush(new BufferStatement("DELETE FROM accounts WHERE name = ?", name));
-        Cache.refresh(name);
     }
 
     public void edit(LoginPlayer lp) throws Exception {
         flush(new BufferStatement("UPDATE accounts SET password = ?, lastAction = ?, email = ?, ips = ?, location = ? WHERE name = ?",
             lp.getPassword(), new Date(), lp.getEmail(), lp.getIps(), lp.getLocation(), lp.getName()));
-        Cache.refresh(lp.getName());
     }
 
     public void updateLocation(String name, String location) throws Exception {

--- a/src/main/java/cc/baka9/catseedlogin/bukkit/object/LoginPlayerHelper.java
+++ b/src/main/java/cc/baka9/catseedlogin/bukkit/object/LoginPlayerHelper.java
@@ -109,6 +109,7 @@ public class LoginPlayerHelper {
         CatSeedLogin.instance.runTaskAsync(() -> {
             try {
                 CatSeedLogin.sql.edit(lp);
+                Cache.refresh(lp.getName());
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/src/main/java/cc/baka9/catseedlogin/bungee/BungeeCommunication.java
+++ b/src/main/java/cc/baka9/catseedlogin/bungee/BungeeCommunication.java
@@ -1,32 +1,41 @@
 package cc.baka9.catseedlogin.bungee;
 
+import cc.baka9.catseedlogin.bungee.config.BungeeConfigManager;
 import cc.baka9.catseedlogin.common.communication.BaseCommunication;
 
 public class BungeeCommunication extends BaseCommunication {
 
+    private final BungeeConfigManager configManager;
+    private final java.util.logging.Logger logger;
+
+    public BungeeCommunication(BungeeConfigManager configManager, java.util.logging.Logger logger) {
+        this.configManager = configManager;
+        this.logger = logger;
+    }
+
     @Override
     protected String getProxyHost() {
-        return PluginMain.instance.getConfigManager().getProxyHost();
+        return configManager.getProxyHost();
     }
 
     @Override
     protected int getProxyPort() {
-        return PluginMain.instance.getConfigManager().getProxyPort();
+        return configManager.getProxyPort();
     }
 
     @Override
     protected void logError(String message, Exception e) {
-        PluginMain.instance.getLogger().severe(message);
+        logger.severe(message);
         e.printStackTrace();
     }
 
     @Override
     protected void logWarning(String message) {
-        PluginMain.instance.getLogger().warning(message);
+        logger.warning(message);
     }
 
     @Override
     protected String getAuthKey() {
-        return PluginMain.instance.getConfigManager().getAuthKey();
+        return configManager.getAuthKey();
     }
 }

--- a/src/main/java/cc/baka9/catseedlogin/bungee/Commands.java
+++ b/src/main/java/cc/baka9/catseedlogin/bungee/Commands.java
@@ -1,19 +1,23 @@
 package cc.baka9.catseedlogin.bungee;
 
+import cc.baka9.catseedlogin.bungee.config.BungeeConfigManager;
 import cc.baka9.catseedlogin.common.i18n.MessageKey;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.chat.TextComponent;
 
 public class Commands extends net.md_5.bungee.api.plugin.Command {
 
-    public Commands(String name, String permission, String... aliases) {
+    private final BungeeConfigManager configManager;
+
+    public Commands(String name, String permission, BungeeConfigManager configManager, String... aliases) {
         super(name, permission, aliases);
+        this.configManager = configManager;
     }
 
     @Override
     public void execute(CommandSender commandSender, String[] args) {
         if (args.length > 0 && args[0].equalsIgnoreCase("reload")) {
-            PluginMain.instance.getConfigManager().reload();
+            configManager.reload();
             commandSender.sendMessage(new TextComponent(MessageKey.CONFIG_RELOADED.get()));
         }
     }

--- a/src/main/java/cc/baka9/catseedlogin/bungee/Listeners.java
+++ b/src/main/java/cc/baka9/catseedlogin/bungee/Listeners.java
@@ -20,6 +20,13 @@ public class Listeners implements Listener {
 
     private final ProxyServer proxyServer = ProxyServer.getInstance();
     private final List<String> loggedInPlayerList = new CopyOnWriteArrayList<>();
+    private final BungeeConfigManager configManager;
+    private final BungeeCommunication communication;
+
+    public Listeners(BungeeConfigManager configManager, BungeeCommunication communication) {
+        this.configManager = configManager;
+        this.communication = communication;
+    }
 
     @EventHandler
     public void onChat(ChatEvent event) {
@@ -37,8 +44,7 @@ public class Listeners implements Listener {
     @EventHandler
     public void onServerConnect(ServerConnectEvent event) {
         ServerInfo target = event.getTarget();
-        BungeeConfigManager config = PluginMain.instance.getConfigManager();
-        String loginServerName = config.getLoginServerName();
+        String loginServerName = configManager.getLoginServerName();
         if (!event.isCancelled() && !target.getName().equals(loginServerName)) {
             ProxiedPlayer player = event.getPlayer();
             String playerName = player.getName();
@@ -46,7 +52,7 @@ public class Listeners implements Listener {
             if (!loggedInPlayerList.contains(playerName)) {
                 PluginMain.runAsync(() -> {
                     try {
-                        if (PluginMain.instance.getCommunication().sendConnectRequest(playerName) == 1) {
+                        if (communication.sendConnectRequest(playerName) == 1) {
                             loggedInPlayerList.add(playerName);
                         } else {
                             event.setTarget(proxyServer.getServerInfo(loginServerName));
@@ -62,12 +68,11 @@ public class Listeners implements Listener {
 
     @EventHandler
     public void onServerConnected(ServerConnectedEvent event) {
-        BungeeConfigManager config = PluginMain.instance.getConfigManager();
-        String loginServerName = config.getLoginServerName();
+        String loginServerName = configManager.getLoginServerName();
         if (event.getServer().getInfo().getName().equals(loginServerName)) {
             ProxiedPlayer player = event.getPlayer();
             if (loggedInPlayerList.contains(player.getName())) {
-                PluginMain.runAsync(() -> PluginMain.instance.getCommunication().sendKeepLoggedInRequest(player.getName()));
+                PluginMain.runAsync(() -> communication.sendKeepLoggedInRequest(player.getName()));
             }
         }
     }
@@ -81,7 +86,7 @@ public class Listeners implements Listener {
     public void onPreLogin(PreLoginEvent event) {
         String playerName = event.getConnection().getName();
         try {
-            if (loggedInPlayerList.contains(playerName) && (PluginMain.instance.getCommunication().sendConnectRequest(playerName) == 1)) {
+            if (loggedInPlayerList.contains(playerName) && (communication.sendConnectRequest(playerName) == 1)) {
                 event.setCancelReason(new TextComponent("您已经登录，请勿重复登录。"));
                 event.setCancelled(true);
             }
@@ -95,7 +100,7 @@ public class Listeners implements Listener {
     private void handleLogin(ProxiedPlayer player, String message) {
         String playerName = player.getName();
         PluginMain.runAsync(() -> {
-            if (PluginMain.instance.getCommunication().sendConnectRequest(playerName) == 1) {
+            if (communication.sendConnectRequest(playerName) == 1) {
                 loggedInPlayerList.add(playerName);
                 if (message != null && !message.isEmpty()) {
                     proxyServer.getPluginManager().dispatchCommand(player, message.substring(1));

--- a/src/main/java/cc/baka9/catseedlogin/bungee/PluginMain.java
+++ b/src/main/java/cc/baka9/catseedlogin/bungee/PluginMain.java
@@ -18,10 +18,10 @@ public class PluginMain extends Plugin {
         instance = this;
         configManager = new BungeeConfigManager(this);
         platformAdapter = new BungeePlatformAdapter(this, configManager.getI18n());
-        communication = new BungeeCommunication();
+        communication = new BungeeCommunication(configManager, getLogger());
         configManager.reload();
-        getProxy().getPluginManager().registerListener(this, new Listeners());
-        getProxy().getPluginManager().registerCommand(this, new Commands("CatSeedLoginBungee", "catseedlogin.admin", "cslb"));
+        getProxy().getPluginManager().registerListener(this, new Listeners(configManager, communication));
+        getProxy().getPluginManager().registerCommand(this, new Commands("CatSeedLoginBungee", "catseedlogin.admin", configManager, "cslb"));
     }
 
     public static ScheduledTask runAsync(Runnable runnable) {

--- a/src/main/java/cc/baka9/catseedlogin/velocity/Commands.java
+++ b/src/main/java/cc/baka9/catseedlogin/velocity/Commands.java
@@ -1,10 +1,13 @@
 package cc.baka9.catseedlogin.velocity;
 
 import cc.baka9.catseedlogin.common.i18n.MessageKey;
+import cc.baka9.catseedlogin.velocity.config.VelocityConfigManager;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.proxy.ProxyServer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,6 +15,18 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public class Commands implements SimpleCommand {
+
+    private final VelocityConfigManager configManager;
+    private final ProxyServer proxyServer;
+    private final Logger logger;
+    private final Listeners listeners;
+
+    public Commands(VelocityConfigManager configManager, ProxyServer proxyServer, Logger logger, Listeners listeners) {
+        this.configManager = configManager;
+        this.proxyServer = proxyServer;
+        this.logger = logger;
+        this.listeners = listeners;
+    }
 
     @Override
     public void execute(Invocation invocation) {
@@ -64,25 +79,25 @@ public class Commands implements SimpleCommand {
     
     private void handleReload(CommandSource source) {
         try {
-            PluginMain.getInstance().getConfigManager().reload();
+            configManager.reload();
             source.sendMessage(Component.text(MessageKey.CONFIG_RELOADED.get()));
         } catch (Exception e) {
             source.sendMessage(Component.text("重载配置文件时出错: " + e.getMessage(), NamedTextColor.RED));
-            PluginMain.getInstance().getLogger().error("Failed to reload config", e);
+            logger.error("Failed to reload config", e);
         }
     }
     
     private void handleStatus(CommandSource source) {
         source.sendMessage(Component.text("=== CatSeedLogin-Velocity 状态 ===", NamedTextColor.GOLD));
         
-        String host = PluginMain.getInstance().getConfigManager().getProxyHost();
-        int port = PluginMain.getInstance().getConfigManager().getProxyPort();
-        String loginServerName = PluginMain.getInstance().getConfigManager().getLoginServerName();
+        String host = configManager.getProxyHost();
+        int port = configManager.getProxyPort();
+        String loginServerName = configManager.getLoginServerName();
         
         source.sendMessage(Component.text("监听地址: " + host + ":" + port, NamedTextColor.YELLOW));
         source.sendMessage(Component.text("登录服务器: " + loginServerName, NamedTextColor.YELLOW));
         
-        boolean loginServerOnline = PluginMain.getInstance().getProxyServer()
+        boolean loginServerOnline = proxyServer
             .getServer(loginServerName)
             .isPresent();
         
@@ -91,7 +106,7 @@ public class Commands implements SimpleCommand {
     }
     
     private void handleList(CommandSource source) {
-        List<String> loggedInPlayers = Listeners.getLoggedInPlayers();
+        List<String> loggedInPlayers = listeners.getLoggedInPlayers();
         
         source.sendMessage(Component.text("=== 已登录玩家列表 ===", NamedTextColor.GOLD));
         source.sendMessage(Component.text("已登录玩家数量: " + loggedInPlayers.size(), NamedTextColor.YELLOW));

--- a/src/main/java/cc/baka9/catseedlogin/velocity/Listeners.java
+++ b/src/main/java/cc/baka9/catseedlogin/velocity/Listeners.java
@@ -7,8 +7,10 @@ import com.velocitypowered.api.event.connection.PreLoginEvent;
 import com.velocitypowered.api.event.player.ServerConnectedEvent;
 import com.velocitypowered.api.event.player.ServerPreConnectEvent;
 import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import net.kyori.adventure.text.Component;
+import org.slf4j.Logger;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -16,7 +18,19 @@ import java.util.concurrent.TimeUnit;
 
 public class Listeners {
 
-    private static final List<String> loggedInPlayerList = new CopyOnWriteArrayList<>();
+    private final List<String> loggedInPlayerList = new CopyOnWriteArrayList<>();
+    private final VelocityConfigManager configManager;
+    private final VelocityCommunication communication;
+    private final ProxyServer proxyServer;
+    private final Logger logger;
+
+    public Listeners(VelocityConfigManager configManager, VelocityCommunication communication,
+                     ProxyServer proxyServer, Logger logger) {
+        this.configManager = configManager;
+        this.communication = communication;
+        this.proxyServer = proxyServer;
+        this.logger = logger;
+    }
 
     @Subscribe
     public void onChat(com.velocitypowered.api.event.player.PlayerChatEvent event) {
@@ -63,25 +77,23 @@ public class Listeners {
         
         String targetName = target.getServerInfo().getName();
         String playerName = player.getUsername();
-        VelocityConfigManager config = PluginMain.getInstance().getConfigManager();
-        String loginServerName = config.getLoginServerName();
+        String loginServerName = configManager.getLoginServerName();
 
         if (!loggedInPlayerList.contains(playerName)) {
             if (!targetName.equals(loginServerName)) {
                 PluginMain.runAsync(() -> {
                     try {
-                        if (PluginMain.getInstance().getCommunication().sendConnectRequest(playerName) == 1) {
+                        if (communication.sendConnectRequest(playerName) == 1) {
                             loggedInPlayerList.add(playerName);
                         } else {
-                            PluginMain.getInstance().getProxyServer()
+                            proxyServer
                                 .getServer(loginServerName)
                                 .ifPresent(loginServer -> {
                                     event.setResult(ServerPreConnectEvent.ServerResult.allowed(loginServer));
                                 });
                         }
                     } catch (Exception e) {
-                        PluginMain.getInstance().getLogger()
-                            .error("Error checking login status for player: " + playerName, e);
+                        logger.error("Error checking login status for player: " + playerName, e);
                     }
                 });
             } else {
@@ -94,12 +106,11 @@ public class Listeners {
     public void onServerConnected(ServerConnectedEvent event) {
         Player player = event.getPlayer();
         String serverName = event.getServer().getServerInfo().getName();
-        VelocityConfigManager config = PluginMain.getInstance().getConfigManager();
-        String loginServerName = config.getLoginServerName();
+        String loginServerName = configManager.getLoginServerName();
         
         if (serverName.equals(loginServerName) && loggedInPlayerList.contains(player.getUsername())) {
             PluginMain.runAsyncDelayed(() -> {
-                PluginMain.getInstance().getCommunication().sendKeepLoggedInRequest(player.getUsername());
+                communication.sendKeepLoggedInRequest(player.getUsername());
             }, 1, TimeUnit.SECONDS);
         }
     }
@@ -115,7 +126,7 @@ public class Listeners {
         String playerName = event.getUsername();
         
         try {
-            if (loggedInPlayerList.contains(playerName) && (PluginMain.getInstance().getCommunication().sendConnectRequest(playerName) == 1)) {
+            if (loggedInPlayerList.contains(playerName) && (communication.sendConnectRequest(playerName) == 1)) {
                 event.setResult(PreLoginEvent.PreLoginComponentResult.denied(
                     Component.text("您已经登录，请勿重复登录。")
                 ));
@@ -132,23 +143,22 @@ public class Listeners {
         
         PluginMain.runAsync(() -> {
             try {
-                if (PluginMain.getInstance().getCommunication().sendConnectRequest(playerName) == 1) {
+                if (communication.sendConnectRequest(playerName) == 1) {
                     loggedInPlayerList.add(playerName);
                     
                     if (message != null && !message.isEmpty() && message.startsWith("/")) {
-                        PluginMain.getInstance().getProxyServer()
+                        proxyServer
                             .getCommandManager()
                             .executeAsync(player, message.substring(1));
                     }
                 }
             } catch (Exception e) {
-                PluginMain.getInstance().getLogger()
-                    .error("Error handling login for player: " + playerName, e);
+                logger.error("Error handling login for player: " + playerName, e);
             }
         });
     }
     
-    public static List<String> getLoggedInPlayers() {
+    public List<String> getLoggedInPlayers() {
         return loggedInPlayerList;
     }
 }

--- a/src/main/java/cc/baka9/catseedlogin/velocity/PluginMain.java
+++ b/src/main/java/cc/baka9/catseedlogin/velocity/PluginMain.java
@@ -32,6 +32,7 @@ public class PluginMain {
     private VelocityConfigManager configManager;
     private VelocityPlatformAdapter platformAdapter;
     private VelocityCommunication communication;
+    private Listeners listeners;
     
     @Inject
     public PluginMain(ProxyServer proxyServer, Logger logger, @DataDirectory Path dataDirectory) {
@@ -61,16 +62,17 @@ public class PluginMain {
     public void onProxyInitialization(ProxyInitializeEvent event) {
         configManager = new VelocityConfigManager(this);
         platformAdapter = new VelocityPlatformAdapter(this, configManager.getI18n());
-        communication = new VelocityCommunication();
+        communication = new VelocityCommunication(configManager, logger);
+        listeners = new Listeners(configManager, communication, proxyServer, logger);
         configManager.reload();
         
-        proxyServer.getEventManager().register(this, new Listeners());
+        proxyServer.getEventManager().register(this, listeners);
         
         proxyServer.getCommandManager().register(
             proxyServer.getCommandManager().metaBuilder("CatSeedLoginVelocity")
                 .aliases("cslv")
                 .build(),
-            new Commands()
+            new Commands(configManager, proxyServer, logger, listeners)
         );
         
         logger.info("CatSeedLogin-Velocity has been enabled!");
@@ -103,5 +105,9 @@ public class PluginMain {
 
     public VelocityCommunication getCommunication() {
         return communication;
+    }
+
+    public Listeners getListeners() {
+        return listeners;
     }
 }

--- a/src/main/java/cc/baka9/catseedlogin/velocity/VelocityCommunication.java
+++ b/src/main/java/cc/baka9/catseedlogin/velocity/VelocityCommunication.java
@@ -1,31 +1,41 @@
 package cc.baka9.catseedlogin.velocity;
 
 import cc.baka9.catseedlogin.common.communication.BaseCommunication;
+import cc.baka9.catseedlogin.velocity.config.VelocityConfigManager;
+import org.slf4j.Logger;
 
 public class VelocityCommunication extends BaseCommunication {
 
+    private final VelocityConfigManager configManager;
+    private final Logger logger;
+
+    public VelocityCommunication(VelocityConfigManager configManager, Logger logger) {
+        this.configManager = configManager;
+        this.logger = logger;
+    }
+
     @Override
     protected String getProxyHost() {
-        return PluginMain.getInstance().getConfigManager().getProxyHost();
+        return configManager.getProxyHost();
     }
 
     @Override
     protected int getProxyPort() {
-        return PluginMain.getInstance().getConfigManager().getProxyPort();
+        return configManager.getProxyPort();
     }
 
     @Override
     protected void logError(String message, Exception e) {
-        PluginMain.getInstance().getLogger().error(message, e);
+        logger.error(message, e);
     }
 
     @Override
     protected void logWarning(String message) {
-        PluginMain.getInstance().getLogger().warn(message);
+        logger.warn(message);
     }
 
     @Override
     protected String getAuthKey() {
-        return PluginMain.getInstance().getConfigManager().getAuthKey();
+        return configManager.getAuthKey();
     }
 }


### PR DESCRIPTION
1.  将SQL类中原有的缓存刷新调用移到各业务逻辑处，统一缓存更新时机
2.  重构CatScheduler，改为通过静态init方法初始化依赖，移除对CatSeedLogin的直接静态依赖
3.  重构Bungee与Velocity端的通信与命令、监听器类，移除对插件主类的静态直接依赖，改为通过构造器注入依赖
4.  修复BungeeCommands类的换行符问题