### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/google-java-format.yml
+++ b/.github/workflows/google-java-format.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   formatting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/shulng/ReCatSeedLogin/security/code-scanning/9](https://github.com/shulng/ReCatSeedLogin/security/code-scanning/9)

To fix this, add an explicit `permissions` block to `.github/workflows/google-java-format.yml`. The best minimal fix, aligned with CodeQL guidance and least privilege, is to set:

- `contents: read`

at the workflow root (applies to all jobs unless overridden). This preserves current behavior for checkout and formatting execution while preventing broader inherited token scopes. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
